### PR TITLE
Add support for frontend and backend auth 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="/" />
     <title>Exploration LLC</title>
 </head>
 <body>

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -33,6 +33,7 @@ authController.authenticate = (req, res, next) => {
         });
       }
       res.locals.message = 'Successful Login';
+      res.locals.user = user;
       return next();
     });
   })(req, res, next);

--- a/server/passport.config.js
+++ b/server/passport.config.js
@@ -3,27 +3,30 @@ const LocalStrategy = require('passport-local').Strategy;
 const bcrypt = require('bcryptjs');
 const Pool = require('./model/database');
 
-passport.use('local', new LocalStrategy((async (username, password, done) => {
-  try {
-    const query = 'SELECT * FROM member WHERE username = $1';
-    const member = await Pool.query(query, [username]);
-    if (member.rows.length === 0) {
-      done(null, false, { message: 'Incorrect username.' });
-    } else {
-      bcrypt.compare(password, member.rows[0].password, (err, isMatch) => {
-        if (err) {
-          done(null, false, { message: `Decrypt error: ${err}` });
-        } 
-        if (isMatch) {
-          const { id, username, password } = member.rows[0];
-          done(null, { id, username, password });
-        } else done(null, false, { message: 'Incorrect password.' });
-      });
+passport.use(
+  'local',
+  new LocalStrategy(async (username, password, done) => {
+    try {
+      const query = 'SELECT * FROM member WHERE username = $1';
+      const member = await Pool.query(query, [username]);
+      if (member.rows.length === 0) {
+        done(null, false, { message: 'Incorrect username.' });
+      } else {
+        bcrypt.compare(password, member.rows[0].password, (err, isMatch) => {
+          if (err) {
+            done(null, false, { message: `Decrypt error: ${err}` });
+          }
+          if (isMatch) {
+            const { id, username } = member.rows[0];
+            done(null, { id, username });
+          } else done(null, false, { message: 'Incorrect password.' });
+        });
+      }
+    } catch (err) {
+      return done(null, false, { message: `${err}` });
     }
-  } catch (err) {
-    return done(null, false, { message: `${err}` });
-  }
-})));
+  })
+);
 
 passport.serializeUser((user, done) => {
   done(null, user.id);

--- a/server/routes/member.js
+++ b/server/routes/member.js
@@ -4,12 +4,20 @@ const route = express.Router();
 const memberController = require('../controllers/memberController');
 const authController = require('../controllers/authController');
 
-route.post('/signup', memberController.validateMember, memberController.createMember, authController.authenticate, (req, res) => {
-  res.status(200).json({ message: res.locals.message });
-});
+route.post(
+  '/signup',
+  memberController.validateMember,
+  memberController.createMember,
+  authController.authenticate,
+  (req, res) => {
+    res
+      .status(200)
+      .json({ message: res.locals.message, user: res.locals.user });
+  }
+);
 
 route.post('/login', authController.authenticate, (req, res) => {
-  res.status(200).json({ message: res.locals.message });
+  res.status(200).json({ message: res.locals.message, user: res.locals.user });
 });
 
 route.get('/logout', authController.logout, (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -44,7 +44,7 @@ app.use('/api/trips', routeTrips);
 if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, '../dist/')));
 
-  app.get('/', (req, res) => {
+  app.get('/*', (req, res) => {
     res.sendFile(path.join(__dirname, '../dist/index.html'));
   });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,12 @@ module.exports = {
       '/': {
         target: 'http://localhost:3000/',
         secure: false,
+        bypass: (req, res, proxyOptions) => {
+          if (req.headers.accept.indexOf('html') !== -1) {
+            // console.log('Skipping proxy for browser request.');
+            return '/index.html';
+          }
+        },
       },
     },
   },


### PR DESCRIPTION
1. Include user in signup and sign in responses.
2. Add support for browser refresh to work with react-routers.
3. Skip proxy for browser request. Added to development and production.   